### PR TITLE
Use the $ServiceName for Creation

### DIFF
--- a/topshelf/Deploy.ps1
+++ b/topshelf/Deploy.ps1
@@ -43,6 +43,5 @@ if(Test-Path "app.config")
 	Copy-Item "app.config" -Destination "$ServiceExecutable.config"
 }
 
-# start !
 Write-Host "Starting the service"
-& "$fullPath" "start" | Write-Host
+Start-Service $ServiceName

--- a/topshelf/Deploy.ps1
+++ b/topshelf/Deploy.ps1
@@ -29,7 +29,7 @@ else
 {
     Write-Host "The service will be stopped and reconfigured"
 
-	& "$fullPath" "stop" | Write-Host
+	Stop-Service $ServiceName
     & "sc.exe" config $service.Name binPath= $fullPath start= auto | Write-Host
 }
 

--- a/topshelf/Deploy.ps1
+++ b/topshelf/Deploy.ps1
@@ -23,7 +23,7 @@ if (! $service)
 {
     Write-Host "The service will be installed"
 
-	& "$fullPath" "install" | Write-Host
+	& "$fullPath" install --servicename:$ServiceName | Write-Host
 }
 else
 {
@@ -33,14 +33,15 @@ else
     & "sc.exe" config $service.Name binPath= $fullPath start= auto | Write-Host
 }
 
+if(Test-Path "app.config")
+{
+	# rename the transformed "app.config" to "MyService.exe.config" as this is not handled automatically
+	# by octopus unless your transforms match the service exe config name ("MyService.<Environment>.exe.config")
+	Write-Host "Copying transformed $OctopusEnvironmentName configuration file"
 
-# rename the transformed "app.config" to "MyService.exe.config" as this is not handled automatically
-# by octopus unless your transforms match the service exe config name ("MyService.<Environment>.exe.config")
-Write-Host "Copying transformed $OctopusEnvironmentName configuration file"
-
-Rename-Item "$ServiceExecutable.config" "$ServiceExecutable.config.original"
-Copy-Item "app.config" -Destination "$ServiceExecutable.config"
-
+	Rename-Item "$ServiceExecutable.config" "$ServiceExecutable.config.original"
+	Copy-Item "app.config" -Destination "$ServiceExecutable.config"
+}
 
 # start !
 Write-Host "Starting the service"


### PR DESCRIPTION
The behavior right now is to ignore the $ServiceName variable and use the TopShelf configured one.

Should use the one that's provided, and use that to start the service at the end. 

Also, added a check for the App.Config file to make sure it exists before trying to copy it.
